### PR TITLE
fail gracefully when an error response doesn't include JSON error fields

### DIFF
--- a/webmentiontools/send.py
+++ b/webmentiontools/send.py
@@ -55,8 +55,8 @@ class WebmentionSend():
                 'code':'RECEIVER_ERROR',
                 'request': 'POST %s (with source=%s, target=%s)' % (self.receiver_endpoint, self.source_url, self.target_url),
                 'http_status': r.status_code,
-                'error': response['error'],
-                'error_description': response['error_description']
+                'error': response.get('error'),
+                'error_description': response.get('error_description')
             }
             return False
         else:


### PR DESCRIPTION
(some webmention implementations don't include the error_description field, e.g. https://github.com/pfefferle/wordpress-webmention . others don't include anything at all.)
